### PR TITLE
Adds partition_index

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ This crate has a `partition(..)` function to partition a mutable slice of
 values by a predicate. It will swap around values to separate those the
 predicate holds for and those it doesn't and return the two mutable sub-slices.
 
+This crate also provides `partition_index(..)` which operates similarly, but
+instead returns the index of the first element to evaluate to false.  All
+elements before this index evaluate to true, and all elements after evaluate
+to false.
+
 ### Warning
 
 Note that since partition works by swapping values, the order of elements within

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ let mut even_odd = [0u8, 1, 2, 3, 4, 5, 6];
 let (even, odd) = partition(&mut even_odd, |x| x & 1 == 0);
 ```
 
+```Rust
+let mut less_than_4 = [0u8, 3, 6, 2, 1, 5, 4];
+let idx = partition_index(&mut less_than_4, |x| x < 4);
+```
+
 ## Performance
 
 On a Core m3-6y30 with 4GB of RAM, I get the following benchmark results

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -4,7 +4,7 @@ extern crate partition;
 
 use rand::Rng;
 use bencher::Bencher;
-use partition::partition;
+use partition::{partition, partition_index};
 
 fn random_values(len: usize) -> Vec<u32> {
     rand::thread_rng().gen_iter::<u32>().take(len).collect()
@@ -15,49 +15,63 @@ fn false_fn(_: &u32) -> bool { false }
 fn odd_fn(x: &u32) -> bool { x % 2 > 0 }
 
 macro_rules! mkbench {
-    ($i: expr, $name_slice: ident, $name_vec: ident, $name_fn: ident) => {
-        fn $name_slice(b: &mut Bencher) {
-            let mut data = random_values($i);
-            b.iter(|| { let (_left, _right) = bencher::black_box(partition(&mut data, |e| $name_fn(e))); });
-        }
+    ($i: expr, $bench_name: ident, $name_fn: ident) => {
+        mod $bench_name {
+            use super::*;
 
-        fn $name_vec(b: &mut Bencher) {
-            let data : Vec<u32> = random_values($i);
-            b.iter(|| data.iter().partition::<Vec<u32>, _>(|e| $name_fn(e)));
+            pub fn slice(b: &mut Bencher) {
+                let mut data = random_values($i);
+                b.iter(|| { let (_left, _right) = bencher::black_box(partition(&mut data, |e| $name_fn(e))); });
+            }
+
+            pub fn index(b: &mut Bencher) {
+                let mut data = random_values($i);
+                b.iter(|| { let _idx = bencher::black_box(partition_index(&mut data, |e| $name_fn(e))); });
+            }
+
+            pub fn vec(b: &mut Bencher) {
+                let data : Vec<u32> = random_values($i);
+                b.iter(|| data.iter().partition::<Vec<u32>, _>(|e| $name_fn(e)));
+            }
         }
     }
 }
 
-mkbench!(1, bench_slice_1_true, bench_vec_1_true, true_fn);
-mkbench!(10, bench_slice_10_true, bench_vec_10_true, true_fn);
-mkbench!(100, bench_slice_100_true, bench_vec_100_true, true_fn);
-mkbench!(1000, bench_slice_1000_true, bench_vec_1000_true, true_fn);
-mkbench!(10_000, bench_slice_10000_true, bench_vec_10000_true, true_fn);
+mkbench!(1, bench_1_true, true_fn);
+mkbench!(10, bench_10_true, true_fn);
+mkbench!(100, bench_100_true, true_fn);
+mkbench!(1000, bench_1000_true, true_fn);
+mkbench!(10_000, bench_10000_true, true_fn);
 
-mkbench!(1, bench_slice_1_false, bench_vec_1_false, false_fn);
-mkbench!(10, bench_slice_10_false, bench_vec_10_false, false_fn);
-mkbench!(100, bench_slice_100_false, bench_vec_100_false, false_fn);
-mkbench!(1000, bench_slice_1000_false, bench_vec_1000_false, false_fn);
-mkbench!(10_000, bench_slice_10000_false, bench_vec_10000_false, false_fn);
+mkbench!(1, bench_1_false, false_fn);
+mkbench!(10, bench_10_false, false_fn);
+mkbench!(100, bench_100_false, false_fn);
+mkbench!(1000, bench_1000_false, false_fn);
+mkbench!(10_000, bench_10000_false, false_fn);
 
-mkbench!(1, bench_slice_1_odd, bench_vec_1_odd, odd_fn);
-mkbench!(10, bench_slice_10_odd, bench_vec_10_odd, odd_fn);
-mkbench!(100, bench_slice_100_odd, bench_vec_100_odd, odd_fn);
-mkbench!(1000, bench_slice_1000_odd, bench_vec_1000_odd, odd_fn);
-mkbench!(10_000, bench_slice_10000_odd, bench_vec_10000_odd, odd_fn);
+mkbench!(1, bench_1_odd, odd_fn);
+mkbench!(10, bench_10_odd, odd_fn);
+mkbench!(100, bench_100_odd, odd_fn);
+mkbench!(1000, bench_1000_odd, odd_fn);
+mkbench!(10_000, bench_10000_odd, odd_fn);
 
 
 benchmark_group!(bench,
-    bench_slice_1_true, bench_slice_1_false, bench_slice_1_odd,
-    bench_vec_1_true, bench_vec_1_false, bench_vec_1_odd,
-    bench_slice_10_true, bench_slice_10_false, bench_slice_10_odd,
-    bench_vec_10_true, bench_vec_10_false, bench_vec_10_odd,
-    bench_slice_100_true, bench_slice_100_false, bench_slice_100_odd,
-    bench_vec_100_true, bench_vec_100_false, bench_vec_100_odd,
-    bench_slice_1000_true, bench_slice_1000_false, bench_slice_1000_odd,
-    bench_vec_1000_true, bench_vec_1000_false, bench_vec_1000_odd,
-    bench_slice_10000_true, bench_slice_10000_false, bench_slice_10000_odd,
-    bench_vec_10000_true, bench_vec_10000_false, bench_vec_10000_odd
+    bench_1_true::slice, bench_1_false::slice, bench_1_odd::slice,
+    bench_1_true::index, bench_1_false::index, bench_1_odd::index,
+    bench_1_true::vec,   bench_1_false::vec,   bench_1_odd::vec,
+    bench_10_true::slice, bench_10_false::slice, bench_10_odd::slice,
+    bench_10_true::index, bench_10_false::index, bench_10_odd::index,
+    bench_10_true::vec,   bench_10_false::vec,   bench_10_odd::vec,
+    bench_100_true::slice, bench_100_false::slice, bench_100_odd::slice,
+    bench_100_true::index, bench_100_false::index, bench_100_odd::index,
+    bench_100_true::vec,   bench_100_false::vec,   bench_100_odd::vec,
+    bench_1000_true::slice, bench_1000_false::slice, bench_1000_odd::slice,
+    bench_1000_true::index, bench_1000_false::index, bench_1000_odd::index,
+    bench_1000_true::vec,   bench_1000_false::vec,   bench_1000_odd::vec,
+    bench_10000_true::slice, bench_10000_false::slice, bench_10000_odd::slice,
+    bench_10000_true::index, bench_10000_false::index, bench_10000_odd::index,
+    bench_10000_true::vec,   bench_10000_false::vec,   bench_10000_odd::vec,
 );
 
 benchmark_main!(bench);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,15 +24,9 @@ extern crate quickcheck;
 /// ```
 pub fn partition<T, P>(data: &mut [T], predicate: P) -> (&mut [T], &mut [T])
 where P: Fn(&T) -> bool {
-    let len = data.len();
-    if len == 0 { return (&mut [], &mut []); }
-    let (mut l, mut r) = (0, len - 1);
-    loop {
-        while l < len && predicate(&data[l]) { l += 1; }
-        while r > 0 && !predicate(&data[r]) { r -= 1; }
-        if l >= r { return data.split_at_mut(l); }
-        data.swap(l, r);
-    }
+    if data.len() == 0 { return (&mut [], &mut []); }
+    let idx = partition_index(data, predicate);
+    return data.split_at_mut(idx);
 }
 
 /// partition a mutable slice in-place so that it contains all elements for
@@ -56,6 +50,7 @@ where P: Fn(&T) -> bool {
 ///     assert!(e & 1 == 1, "expected elements after first_odd to be odd, found {:?}", e);
 ///   } 
 /// }
+#[inline]
 pub fn partition_index<T, P>(data: &mut [T], predicate: P) -> usize
 where P: Fn(&T) -> bool {
     let len = data.len();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,30 +35,68 @@ where P: Fn(&T) -> bool {
     }
 }
 
+/// partition a mutable slice in-place so that it contains all elements for
+/// which `predicate(e)` is `true`, followed by all elements for which
+/// `predicate(e)` is `false`.
+/// Returns the index of the first element which returned false.
+/// Returns 0 if all elements returned false.
+/// Returns `data.len()` if all elements returned true.
+///
+/// Examples
+///
+/// ```
+///# use partition::partition_index;
+/// let mut even_odd = [0u8, 1, 2, 3, 4, 5, 6];
+/// let first_odd = partition_index(&mut even_odd, |x| x & 1 == 0);
+/// assert_eq!(first_odd, 4, "expected an index of 4, got {:?}", first_odd);
+/// for (idx, &e) in even_odd.iter().enumerate() {
+///   if idx < first_odd {
+///     assert!(e & 1 == 0, "expected elements before first_odd to be even, found {:?}", e);
+///   } else {
+///     assert!(e & 1 == 1, "expected elements after first_odd to be odd, found {:?}", e);
+///   } 
+/// }
+pub fn partition_index<T, P>(data: &mut [T], predicate: P) -> usize
+where P: Fn(&T) -> bool {
+    let len = data.len();
+    if len == 0 { return 0; }
+    let (mut l, mut r) = (0, len - 1);
+    loop {
+        while l < len && predicate(&data[l]) { l += 1; }
+        while r > 0 && !predicate(&data[r]) { r -= 1; }
+        if l >= r { return l; }
+        data.swap(l, r);
+    }
+}
+
+
 #[cfg(test)]
 mod tests {
-    use super::partition;
+    use super::{partition, partition_index};
     use quickcheck::QuickCheck;
 
     #[test]
     fn test_empty() {
         let empty : &mut [usize] = &mut [][..];
         assert_eq!((&mut [][..], &mut [][..]), partition(empty, |_| true));
+        assert_eq!(0, partition_index(empty, |_| true));
     }
 
     #[test]
     fn test_single_true() {
         assert_eq!((&mut [1][..], &mut [][..]), partition(&mut [1u8][..], |_| true));
+        assert_eq!(1, partition_index(&mut [1u8][..], |_| true));
     }
 
     #[test]
     fn test_single_false() {
         assert_eq!((&mut [][..], &mut [1][..]), partition(&mut [1u8][..], |_| false));
+        assert_eq!(0, partition_index(&mut [1u8][..], |_| false));
     }
 
     #[test]
     fn quickcheck() {
-        fn prop(data: Vec<u32>) -> bool {
+        fn prop_partition(data: Vec<u32>) -> bool {
             let mut data = data;
             let mut trues = data.iter().cloned().filter(|e| e % 2 == 0).collect::<Vec<u32>>();
             let mut falses = data.iter().cloned().filter(|e| e % 2 != 0).collect::<Vec<u32>>();
@@ -69,6 +107,23 @@ mod tests {
             right.sort();
             trues == left && falses == right
         }
-        QuickCheck::new().tests(10000).quickcheck(prop as fn(Vec<u32>) -> bool);
+
+        fn prop_partition_index(data: Vec<u32>) -> bool {
+            let mut data = data;
+            let mut trues = data.iter().cloned().filter(|e| e % 2 == 0).collect::<Vec<u32>>();
+            let mut falses = data.iter().cloned().filter(|e| e % 2 != 0).collect::<Vec<u32>>();
+            let first_false = partition_index(&mut data, |&e| e % 2 == 0);
+            let (mut left, mut right) = (
+                data[0..first_false].iter().cloned().collect::<Vec<u32>>(),
+                data[first_false..].iter().cloned().collect::<Vec<u32>>()
+            );
+            trues.sort();
+            falses.sort();
+            left.sort();
+            right.sort();
+            trues == left && falses == right
+        }
+        QuickCheck::new().tests(10000).quickcheck(prop_partition as fn(Vec<u32>) -> bool);
+        QuickCheck::new().tests(10000).quickcheck(prop_partition_index as fn(Vec<u32>) -> bool);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@ extern crate quickcheck;
 /// ```
 pub fn partition<T, P>(data: &mut [T], predicate: P) -> (&mut [T], &mut [T])
 where P: Fn(&T) -> bool {
-    if data.len() == 0 { return (&mut [], &mut []); }
     let idx = partition_index(data, predicate);
     return data.split_at_mut(idx);
 }


### PR DESCRIPTION
Often times there are algorithms that are better implemented knowing the
midpoint of the partition, rather than the two slices.

partition_index returns the first index that evaluates to false, or one
past the end if all elements evaluated to true.

I updated the tests and benches, and mentioned it in the readme, but I
didn't update the benchmark table in the readme, since I'm on a
different machine than those statistics were originally collected with.

Closes #4 